### PR TITLE
Add file-saver and checkeasy license notice

### DIFF
--- a/LicenseNotes.json
+++ b/LicenseNotes.json
@@ -130,5 +130,6 @@
 
   {"licTypeName": "Apache-2.0", "compName": "google-auth-library-python", "compVersion": "2.11", "copyright": "Copyright 2016 Google LLC", "copyrightSource": "https://github.com/googleapis/google-auth-library-python/blob/v2.11.0/google/oauth2/credentials.py"},
   {"licTypeName": "MIT", "compName": "com.auth0-jwks-rsa", "compVersion": "0.21.1", "copyright": "Copyright (c) 2016 Auth0, Inc. <support@auth0.com> (http://auth0.com)", "copyrightSource": "https://github.com/auth0/jwks-rsa-java/blob/0.21.1/LICENSE"},
-  {"licTypeName": "MIT", "compName": "file-saver", "compVersion": "2.0.5", "copyright": "Copyright © 2016 Eli Grey (http://eligrey.com/).", "copyrightSource": "https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md"}
+  {"licTypeName": "MIT", "compName": "file-saver", "compVersion": "2.0.5", "copyright": "Copyright © 2016 Eli Grey (http://eligrey.com/).", "copyrightSource": "https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md"},
+  {"licTypeName": "ISC", "compName": "checkeasy", "compVersion": "1.1.0", "copyright": "Copyright 2021 Roman Ditchuk", "copyrightSource": "https://github.com/smbwain/checkeasy/blob/master/LICENSE.txt"}
 ]

--- a/LicenseNotes.json
+++ b/LicenseNotes.json
@@ -129,5 +129,6 @@
   {"licTypeName": "Apache-2.0", "compName": "Apache JMeter", "compVersion": "5.5-rc3", "copyright": "unknown", "copyrightSource": "https://github.com/apache/jmeter/blob/v5.5-rc3/LICENSE"},
 
   {"licTypeName": "Apache-2.0", "compName": "google-auth-library-python", "compVersion": "2.11", "copyright": "Copyright 2016 Google LLC", "copyrightSource": "https://github.com/googleapis/google-auth-library-python/blob/v2.11.0/google/oauth2/credentials.py"},
-  {"licTypeName": "MIT", "compName": "com.auth0-jwks-rsa", "compVersion": "0.21.1", "copyright": "Copyright (c) 2016 Auth0, Inc. <support@auth0.com> (http://auth0.com)", "copyrightSource": "https://github.com/auth0/jwks-rsa-java/blob/0.21.1/LICENSE"}
+  {"licTypeName": "MIT", "compName": "com.auth0-jwks-rsa", "compVersion": "0.21.1", "copyright": "Copyright (c) 2016 Auth0, Inc. <support@auth0.com> (http://auth0.com)", "copyrightSource": "https://github.com/auth0/jwks-rsa-java/blob/0.21.1/LICENSE"},
+  {"licTypeName": "MIT", "compName": "file-saver", "compVersion": "2.0.5", "copyright": "Copyright © 2016 Eli Grey (http://eligrey.com/).", "copyrightSource": "https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md"}
 ]


### PR DESCRIPTION
Will be used for exporting (downloading) configuration files Gamify-IT/issues#270